### PR TITLE
Fix NullPointerException when cljs.env/*compiler* is nil

### DIFF
--- a/src/cljss/core.clj
+++ b/src/cljss/core.clj
@@ -2,7 +2,9 @@
   (:require [cljs.analyzer.api :as ana-api]
             [clojure.string :as s]))
 
-(def css-output-to (:css-output-to (ana-api/get-options)))
+(def css-output-to
+  (when cljs.env/*compiler*
+    (:css-output-to (ana-api/get-options))))
 
 (when css-output-to
   (spit css-output-to ""))


### PR DESCRIPTION
Hi there. First off, thank you for writing this library! I've found myself wanting functionality like this in ClojureScript for a while, and I'm eager to use it in upcoming projects.

I found a bug when loading the `cljss.core` namespace in my project. It seems if `cljs.env/*compiler*` is nil then the `cljs.analyzer.api/get-options` function throws a NullPointerException. Adding a condition to handle this resolved the issue on my end. Let me know what you think.