### PR TITLE
Document alternative :validate-config Figwheel option

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Compiler options
 
 If you are using [Figwheel](https://github.com/bhauman/lein-figwheel) with build config validation enabled, you'll see an error `The key :css-output-to is unrecognized` in REPL when starting a project.
 Set `:validate-interactive :start` in Figwheel config to prevent it from interrupting startup. Validation errors still will be displayed.
+This may also be achieved using `:validate-config :ignore-unknown-keys` to only validate options Figwheel recognizes.
 
 ## License
 


### PR DESCRIPTION
I was having trouble using `:validate-interactive :start` in my build environment that uses `figwheel-sidecar`.

Another way of getting this library to work with Figwheel is to set `:validate-config :ignore-unknown-keys`. This is actually a bit cleaner for my use case as it doesn't spit out an error, but it will validate keys Figwheel recognizes.