### PR TITLE
Add an empty .cljs file, so core namespace is not ignored by the compiler

### DIFF
--- a/src/cljss/core.cljs
+++ b/src/cljss/core.cljs
@@ -1,0 +1,1 @@
+(ns ^{:doc "Empty namespace, just so that the macros defined are picked up by the compiler"} cljss.core)


### PR DESCRIPTION
On a vanilla project, adding `cljss` as a dependency and trying to require it would give a:

```
No such namespace: cljss.core, could not locate cljss/core.cljs, cljss/core.cljc, 
or Closure namespace "cljss.core"
```

Since there is no `.cljs` file on the project, compilation might be ignoring the namespace.
This PR adds an empty namespace on a `.cljs` file to circumvent this problem.