### PR TITLE
Adds figwheel to example project

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ Set `goog.DEBUG` to `false` to enable fast path styles injection.
 
 ## Roadmap
 - Media Queries syntax
-- Keyframe Animation syntax
 - Server-side rendering
 
 ## Contributing
@@ -172,6 +171,18 @@ Set `goog.DEBUG` to `false` to enable fast path styles injection.
 - Stick to project's code style as much as possible
 - Make small commits with descriptive commit messages
 - Submit a PR with detailed description of what was done
+
+
+## Development
+
+A repl for the example project is provided via [lein-figwheel](https://github.com/bhauman/lein-figwheel).
+
+```
+$ cd example
+$ lein figwheel
+```
+
+If using emacs [cider](https://github.com/clojure-emacs/cider) - you can also launch the repl using `M-x cider-jack-in-clojurescript`.
 
 ## License
 

--- a/example/project.clj
+++ b/example/project.clj
@@ -12,13 +12,15 @@
                  [reagent "0.7.0"]
                  [org.omcljs/om "1.0.0-beta1"]]
 
-  :plugins [[lein-cljsbuild "1.1.6" :exclusions [[org.clojure/clojure]]]]
+  :plugins [[lein-figwheel "0.5.13"]
+            [lein-cljsbuild "1.1.7" :exclusions [[org.clojure/clojure]]]]
 
   :source-paths ["src"]
 
   :cljsbuild {:builds
               [{:id "dev"
                 :source-paths ["src" "../src"]
+                :figwheel {:open-urls ["http://localhost:3450/index.html"]}
                 :compiler {:main example.core
                            :asset-path "js/compiled/out"
                            :output-to "resources/public/js/compiled/example.js"
@@ -33,9 +35,12 @@
                            :optimizations :advanced
                            :pretty-print false}}]}
 
+  :figwheel {:server-port 3450}
+
   :profiles {:dev {:dependencies [[binaryage/devtools "0.9.2"]
-                                  [com.cemerick/piggieback "0.2.1"]]
-                   :source-paths ["src"]
+                                  [figwheel-sidecar "0.5.13"]
+                                  [com.cemerick/piggieback "0.2.2"]]
+                   :source-paths ["src" "../src"]
                    :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
                    :clean-targets ^{:protect false} ["resources/public/js/compiled"
                                                      :target-path]}})

--- a/example/src/example/core.cljs
+++ b/example/src/example/core.cljs
@@ -5,9 +5,9 @@
             [om.next :as om :refer [defui]]
             [goog.dom :as gdom]
             [cljss.core :refer [defstyles defkeyframes]]
-            [cljss.reagent :as rss]
-            [cljss.rum :as rumss]
-            [cljss.om :as omss]))
+            [cljss.reagent :as rss :include-macros true]
+            [cljss.rum :as rumss :include-macros true]
+            [cljss.om :as omss :include-macros true]))
 
 (defkeyframes bounce [bounce-height]
   {[:from 20 53 80 :to] {:transform "translate3d(0,0,0)"}

--- a/src/cljss/om.cljs
+++ b/src/cljss/om.cljs
@@ -1,4 +1,4 @@
 (ns cljss.om
-  (:require [cljss.core :refer [make-styled]]))
+  (:require [cljss.core :refer-macros [make-styled]]))
 
 (make-styled)

--- a/src/cljss/reagent.cljs
+++ b/src/cljss/reagent.cljs
@@ -1,4 +1,4 @@
 (ns cljss.reagent
-  (:require [cljss.core :refer [make-styled]]))
+  (:require [cljss.core :refer-macros [make-styled]]))
 
 (make-styled)

--- a/src/cljss/rum.cljs
+++ b/src/cljss/rum.cljs
@@ -1,4 +1,4 @@
 (ns cljss.rum
-  (:require [cljss.core :refer [make-styled]]))
+  (:require [cljss.core :refer-macros [make-styled]]))
 
 (make-styled)


### PR DESCRIPTION
@roman01la I figured myself and others could benefit from having a repl and live reloading in the example project.

This is the bare minimum required to get figwheel up and running.

Of note was figwheel seemed to be a bit picky about how it was including macros. So the example project now uses `:include-macros`

`src/cljss/om.cljs` was the only namespace that complained about `:refer` for the `make-styled` macro. I'm not exactly sure why - but I didn't think that detail was important.

Thoughts?