### PR TITLE
Places cider/emacs explanation in correct location

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ $ cd example
 $ lein figwheel
 ```
 
+If using emacs [cider](https://github.com/clojure-emacs/cider) - you can also launch the repl using `M-x cider-jack-in-clojurescript`.
+
 ## Testing
 
 cljss uses a combination of Clojure and ClojureScript tests. Clojure tests are run via `lein test` and ClojureScript tests are run via [doo](https://github.com/bensu/doo). ClojureScript tests require a valid environment in order to run - [PhantomJS](http://phantomjs.org/) being the easiest to install.
@@ -240,8 +242,6 @@ To run Clojure and ClojureScript tests at once use the `test-all` task:
 ```
 $ lein test-all
 ```
-
-If using emacs [cider](https://github.com/clojure-emacs/cider) - you can also launch the repl using `M-x cider-jack-in-clojurescript`.
 
 ## License
 


### PR DESCRIPTION
Looks like I messed the README up in the last PR 😟 