### PR TITLE
Remove global call of js/React createElement in favor of reagent.core/create-element

### DIFF
--- a/src/cljss/reagent.clj
+++ b/src/cljss/reagent.clj
@@ -5,7 +5,7 @@
   (let [cls-name# (var->cls-name var)
         cmp-name# (var->cmp-name var)
         [tag# static# vals# attrs#] (->styled tag styles cls-name#)
-        create-element# `#(apply js/React.createElement ~tag# (cljs.core/clj->js %1) (map reagent.core/as-element %2))]
+        create-element# `#(apply reagent.core/create-element ~tag# (cljs.core/clj->js %1) (map reagent.core/as-element %2))]
     `(do
        (def ~var
          (cljss.reagent/styled ~cls-name# ~static# ~vals# ~attrs# ~create-element#))


### PR DESCRIPTION
Addresses issue I encountered https://github.com/clj-commons/cljss/issues/65#issuecomment-854933577 
Namely React being undefined globally.